### PR TITLE
Add zosma-qa to Test Frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [Optimus](https://github.com/testvagrant/optimusTemplate) - Cucumber based Mobile Automation Framework, which supports test parallelization.
 - [PageObject Pattern Framework](https://github.com/saikrishna321/PageObjectPatternAppium) - Sample Page Object Pattern Framework to use directly.
 - [Parallel Framework Java-Client](https://github.com/saikrishna321/AppiumTestDistribution) - Run appium tests in parallel across iOS and Android devices.
+- [zosma-qa](https://github.com/zosmaai/zosma-qa) - Unified QA platform with one CLI for Appium mobile testing, Playwright web E2E, and k6 load tests — includes zero-config scaffolding, WebdriverIO test helpers, and AI agents that autonomously plan, generate, and self-heal your test suites.
 
 ## Community
 - [Discuss](https://discuss.appium.io)


### PR DESCRIPTION
## Summary
- Adds [zosma-qa](https://github.com/zosmaai/zosma-qa) to the **Test Frameworks** section

## About zosma-qa
Unified QA platform with one CLI for Appium mobile testing, Playwright web E2E, and k6 load tests — includes zero-config scaffolding, WebdriverIO test helpers, and AI agents that autonomously plan, generate, and self-heal your test suites.

## Checklist
- [x] Entry added in alphabetical order within the section
- [x] Link points to a valid, active repository
- [x] Description is concise and informative